### PR TITLE
Add retake_score to lesson endpoint

### DIFF
--- a/source/includes/_lessons.md
+++ b/source/includes/_lessons.md
@@ -44,7 +44,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id
   "id": 1,
   "title": "Lesson 1",
   "assignees_count": 10,
-  "completed_count": 5
+  "completed_count": 5,
+  "retake_score": 80
 }
 ```
 


### PR DESCRIPTION
I'm adding `retake_score` to the lesson GET endpoint in https://github.com/lessonly/lesson.ly/pull/1721. This updates the documentation to reflect that.