### PR TITLE
Update API doc for tags

### DIFF
--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -29,3 +29,30 @@ This endpoint retrieves all tags.
 ### HTTP Request
 
 `GET https://api.lesson.ly/api/v1/tags`
+
+## Show Tag Details
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+    "type": "tag",
+    "id": 1,
+    "name": "Marketing"
+}
+```
+
+This endpoint retrieves all the tag details.
+### HTTP Request
+
+`GET https://api.lesson.ly/api/v1/tags/:tag_id`
+
+### Query Parameters
+
+Paramter | Required | Type |  Description
+--- | --- | --- | ---
+tag_id | yes | Positive Integer | The tag to access.  The company must have access to the tag.

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -1,0 +1,31 @@
+# Tags
+
+## List Tags
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+    "type": "tags",
+    "tags": [
+        {
+            "id": 1,
+            "name": "Marketing"
+        },
+        {
+            "id": 2,
+            "name": "Development"
+        }
+    ]
+}
+```
+
+This endpoint retrieves all tags.
+
+### HTTP Request
+
+`GET https://api.lesson.ly/api/v1/tags`

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -10,17 +10,17 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags"
 
 ```json
 {
-    "type": "tags",
-    "tags": [
-        {
-            "id": 1,
-            "name": "Marketing"
-        },
-        {
-            "id": 2,
-            "name": "Development"
-        }
-    ]
+  "type": "tags",
+  "tags": [
+    {
+      "id": 1,
+      "name": "Marketing"
+    },
+    {
+      "id": 2,
+      "name": "Development"
+    }
+  ]
 }
 ```
 
@@ -40,9 +40,9 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id
 
 ```json
 {
-    "type": "tag",
-    "id": 1,
-    "name": "Marketing"
+  "type": "tag",
+  "id": 1,
+  "name": "Marketing"
 }
 ```
 
@@ -67,25 +67,25 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/lessons
 
 ```json
 {
-    "type": "tag_lessons",
-    "lessons": [
-        {
-            "id": 5,
-            "title": "Marketing 101",
-            "assignees_count": 21,
-            "completed_count": 1,
-            "retake_score": 90,
-            "description": "A quick overview about how we do marketing."
-        },
-        {
-            "id": 456,
-            "title": "Development 101",
-            "assignees_count": 11,
-            "completed_count": 5,
-            "retake_score": 95,
-            "description": "A quick overview about how we do development."
-        }
-    ]
+  "type": "tag_lessons",
+  "lessons": [
+    {
+      "id": 5,
+      "title": "Marketing 101",
+      "assignees_count": 21,
+      "completed_count": 1,
+      "retake_score": 90,
+      "description": "A quick overview about how we do marketing."
+    },
+    {
+      "id": 456,
+      "title": "Development 101",
+      "assignees_count": 11,
+      "completed_count": 5,
+      "retake_score": 95,
+      "description": "A quick overview about how we do development."
+    }
+  ]
 }
 ```
 
@@ -110,34 +110,34 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/courses
 
 ```json
 {
-    "type": "tag_courses",
-    "courses": [
+  "type": "tag_courses",
+  "courses": [
+    {
+      "id": 123,
+      "title": "Onboarding Course",
+      "assignees_count": 15,
+      "completed_count": 11,
+      "description": "This course will get you up to speed in our company.",
+      "lessons": [
         {
-            "id": 123,
-            "title": "Onboarding Course",
-            "assignees_count": 15,
-            "completed_count": 11,
-            "description": "This course will get you up to speed in our company.",
-            "lessons": [
-              {
-                  "id": 5,
-                  "title": "Marketing 101",
-                  "assignees_count": 21,
-                  "completed_count": 1,
-                  "retake_score": 90,
-                  "description": "A quick overview about how we do marketing."
-              },
-              {
-                  "id": 456,
-                  "title": "Development 101",
-                  "assignees_count": 11,
-                  "completed_count": 5,
-                  "retake_score": 95,
-                  "description": "A quick overview about how we do development."
-              }
-            ]
+          "id": 5,
+          "title": "Marketing 101",
+          "assignees_count": 21,
+          "completed_count": 1,
+          "retake_score": 90,
+          "description": "A quick overview about how we do marketing."
+        },
+        {
+          "id": 456,
+          "title": "Development 101",
+          "assignees_count": 11,
+          "completed_count": 5,
+          "retake_score": 95,
+          "description": "A quick overview about how we do development."
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -99,3 +99,55 @@ This endpoint retrieves all the lessons tagged with a particular tag.
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 tag_id | yes | Positive Integer | The tag to access.  The company must have access to the tag.
+
+## Tag Courses
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/courses
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+    "type": "tag_courses",
+    "courses": [
+        {
+            "id": 123,
+            "title": "Onboarding Course",
+            "assignees_count": 15,
+            "completed_count": 11,
+            "description": "This course will get you up to speed in our company.",
+            "lessons": [
+              {
+                  "id": 5,
+                  "title": "Marketing 101",
+                  "assignees_count": 21,
+                  "completed_count": 1,
+                  "retake_score": 90,
+                  "description": "A quick overview about how we do marketing."
+              },
+              {
+                  "id": 456,
+                  "title": "Development 101",
+                  "assignees_count": 11,
+                  "completed_count": 5,
+                  "retake_score": 95,
+                  "description": "A quick overview about how we do development."
+              }
+            ]
+        }
+    ]
+}
+```
+
+This endpoint retrieves all the courses tagged with a particular tag.
+### HTTP Request
+
+`GET https://api.lesson.ly/api/v1/tags/:tag_id/courses`
+
+### Query Parameters
+
+Paramter | Required | Type |  Description
+--- | --- | --- | ---
+tag_id | yes | Positive Integer | The tag to access.  The company must have access to the tag.

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -56,3 +56,46 @@ This endpoint retrieves all the tag details.
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 tag_id | yes | Positive Integer | The tag to access.  The company must have access to the tag.
+
+## Tag Lessons
+
+```shell
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/tags/:tag_id/lessons
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+    "type": "tag_lessons",
+    "lessons": [
+        {
+            "id": 5,
+            "title": "Marketing 101",
+            "assignees_count": 21,
+            "completed_count": 1,
+            "retake_score": 90,
+            "description": "A quick overview about how we do marketing."
+        },
+        {
+            "id": 456,
+            "title": "Development 101",
+            "assignees_count": 11,
+            "completed_count": 5,
+            "retake_score": 95,
+            "description": "A quick overview about how we do development."
+        }
+    ]
+}
+```
+
+This endpoint retrieves all the lessons tagged with a particular tag.
+### HTTP Request
+
+`GET https://api.lesson.ly/api/v1/tags/:tag_id/lessons`
+
+### Query Parameters
+
+Paramter | Required | Type |  Description
+--- | --- | --- | ---
+tag_id | yes | Positive Integer | The tag to access.  The company must have access to the tag.


### PR DESCRIPTION
## Why

https://github.com/lessonly/lesson.ly/issues/1946 and https://github.com/lessonly/lesson.ly/issues/1850 added tags functionality to the API.

## What

This PR adds the documentation for those. Specifically, the following endpoints:

- `GET /api/v1/tags`
- `GET /api/v1/tags/:tag_id`
- `GET /api/v1/tags/:tag_id/lessons`
- `GET /api/v1/tags/:tag_id/courses`

## Deploy notes

We should get this out fairly quickly, as the API has been updated in production and there's not yet any documentation for the new stuff. When this is merged:

- [ ] Pull `master` locally
- [ ] `$ rake publish` to get the changes live