### PR TITLE
Document the notify option when making assignments

### DIFF
--- a/source/includes/_courses.md
+++ b/source/includes/_courses.md
@@ -135,7 +135,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses/:course_id/assign
   "assignments":[
     {
       "assignee_id": 1,
-      "due_by": "2020-09-30T00:00:00Z"
+      "due_by": "2020-09-30T00:00:00Z",
+      "notify": true
     }
   ]
 }
@@ -152,6 +153,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/courses/:course_id/assign
       "id": 1,
       "resource_type": "assignment",
       "assignee_id": 1,
+      "assignable_type": "Course",
+      "assignable_id": 3,
       "ext_uid": "ABC123",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
@@ -174,5 +177,5 @@ This endpoint allows you to make assignments to a particular course in the API.
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 course_id | yes | Positive Integer | The course to access. The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course.
+assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course. Set `notify` to `true` to send an email to the assignee.
 

--- a/source/includes/_lessons.md
+++ b/source/includes/_lessons.md
@@ -184,7 +184,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id/assign
   "assignments":[
     {
       "assignee_id": 1,
-      "due_by": "2020-09-30T00:00:00Z"
+      "due_by": "2020-09-30T00:00:00Z",
+      "notify": true
     }
   ]
 }
@@ -201,6 +202,8 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id/assign
       "id": 1,
       "resource_type": "assignment",
       "assignee_id": 1,
+      "assignable_type": "Lesson",
+      "assignable_id": 3,
       "ext_uid": "ABC123",
       "due_by": "2020-09-30T00:00:00Z",
       "reassigned_at": "2020-09-30T00:00:00Z",
@@ -224,4 +227,4 @@ This endpoint allows you to make assignments to a particular lesson in the API.
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson.
+assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. `notify` is optional and defaults to `false`.

--- a/source/includes/_lessons.md
+++ b/source/includes/_lessons.md
@@ -227,4 +227,4 @@ This endpoint allows you to make assignments to a particular lesson in the API.
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. `notify` is optional and defaults to `false`.
+assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. Set `notify` to `true` to send an email to the assignee.


### PR DESCRIPTION
Resolves #20 

When making course and lesson assignments, you can specify `"notify": true` or `"notify": false` for each assignment. This PR adds the description for that.

## Merging

Don't forget to deploy these changes after merging!