### PR TITLE
Update groups API examples to match actual API responses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     kramdown (1.9.0)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -133,4 +133,4 @@ DEPENDENCIES
   therubyracer (~> 0.12.1)
 
 BUNDLED WITH
-   1.10.6
+   1.12.3

--- a/source/includes/_groups.md
+++ b/source/includes/_groups.md
@@ -35,8 +35,9 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/:group_id"
 ```json
 {
   "type": "group",
-  "name": "Test Group",
   "resource_type": "group",
+  "id": 12345,
+  "name": "Test Group",
   "members": [
          {"id": 1, "ext_uid": "ABC123", "name": "Test Name"},
          {"id": 2, "ext_uid": "DEF456", "name": "Test Name 2"}
@@ -90,6 +91,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/" -p params
 {
   "type": "create_group",
   "resource_type": "group",
+  "id": 12345,
   "name": "New Name",
   "members": [
          {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"},
@@ -128,7 +130,6 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/:group_id" -p para
 ```json
 { 
   "name": "New Name",
-  "resource_type": "group",
   "members":
     [ 
       {"id": 1 },
@@ -149,6 +150,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/:group_id" -p para
 {
   "type": "update_group",
   "resource_type": "group",
+  "id": 12345,
   "name": "New Name",
   "members": [
          {"id": 1, "ext_uid": "ABC123", "name": "Test Name 1"},

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -58,7 +58,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/users/:user_id
 > The above command returns JSON structured like this:
 
 ```json
- {
+{
   "type": "user",
   "resource_type": "user",
   "id": 1, 
@@ -322,8 +322,9 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/users/:user_id/groups/" -
 > A successful update will return JSON consisting of the user group repsonse:
 
 ```json
-{"type": "update_user_groups",
- "memberships":
+{
+  "type": "update_user_groups",
+  "memberships":
     [ 
         {"id": 1, "name": "Test Group"},
         {"id": 3, "name": "Test Group 3"},


### PR DESCRIPTION
Notably:

- For groups: `show`, `create`, and `update` all return an `id` attribute, which we'd left out
- `resource_type` not required/used in *request* params when updating groups

Also:

- I also fix a bit of inconsistent spacing in the users API docs
- and bump the version of our `libv8` gem to [fix an issue on OSX 10.9+](http://stackoverflow.com/questions/19577759/installing-libv8-gem-on-os-x-10-9)

## Testing Notes

`bundle exec middleman` to run the docs locally at `http://localhost:4567`

## Deploy Notes

    $ bundle exec rake publish