### PR TITLE
Add note about notifications and fix typo in args

### DIFF
--- a/source/includes/_courses.md.erb
+++ b/source/includes/_courses.md.erb
@@ -149,7 +149,7 @@ per_page | no | how many results to return in each page.  Default = 50
     {
       "assignee_id": 1,
       "due_by": "2020-09-30T00:00:00Z",
-      "notify": true
+      "notify": false
     }
   ]
 }
@@ -183,11 +183,11 @@ This endpoint allows you to make assignments to a particular course in the API.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/courses/:course_id/assignments -p params`
+`PUT https://api.lesson.ly/api/v1/courses/:course_id/assignments -d params`
 
 ### Query Parameters
 
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 course_id | yes | Positive Integer | The course to access. The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course. Set `notify` to `true` to send an email to the assignee; it will come from notifications@lesson.ly.
+assignments | no | Hash | A hash of assignments to be made to the course.  If the assignment for a particular user already exists, the user will be reassigned the course. By default, an email will be sent to the assignee; it will come from notifications@lesson.ly. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_groups.md
+++ b/source/includes/_groups.md
@@ -63,7 +63,7 @@ group_id | yes | Positive Integer | The group to access.  The company must have 
 ## Create Group
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/" -p params
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/" -d params
 ```
 
 > The following are sample parameters for this request:
@@ -108,7 +108,7 @@ This endpoint allows you to update a group and its members and managers
 
 ### HTTP Request
 
-`POST https://api.lesson.ly/api/v1/groups/` -p params
+`POST https://api.lesson.ly/api/v1/groups/` -d params
 
 ### Query Parameters
 
@@ -122,7 +122,7 @@ managers | no | Array | The managers of a group.
 ## Update Group
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/:group_id" -p params
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/groups/:group_id" -d params
 ```
 
 > The following are sample parameters for this request:
@@ -165,7 +165,7 @@ This endpoint allows you to update a group and its members and managers
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/groups/:group_id/` -p params
+`PUT https://api.lesson.ly/api/v1/groups/:group_id/` -d params
 
 ### Query Parameters
 

--- a/source/includes/_lessons.md.erb
+++ b/source/includes/_lessons.md.erb
@@ -71,7 +71,7 @@ This endpoint retrieves all the lesson details including statistics about the co
 ## Update Lesson
 
 ```shell
-curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id -p params
+curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id -d params
 ```
 
 > The above command returns JSON structured like this:
@@ -103,7 +103,7 @@ curl -u "DOMAIN:API_KEY" "https://api.lesson.ly/api/v1/lessons/:lesson_id -p par
 This endpoint allows the updating of a single lesson and its attributes
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id -p params`
+`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id -d params`
 
 ### Query Parameters
 
@@ -186,7 +186,7 @@ per_page | no | how many results to return in each page.  Default = 50
     {
       "assignee_id": 1,
       "due_by": "2020-09-30T00:00:00Z",
-      "notify": true
+      "notify": false
     }
   ]
 }
@@ -221,11 +221,11 @@ This endpoint allows you to make assignments to a particular lesson in the API.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id/assignments -p params`
+`PUT https://api.lesson.ly/api/v1/lessons/:lesson_id/assignments -d params`
 
 ### Query Parameters
 
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 lesson_id | yes | Positive Integer | The lesson to access.  The company must have access to the user.
-assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. Set `notify` to `true` to send an email to the assignee; it will come from notifications@lesson.ly.
+assignments | no | Hash | A hash of assignments to be made to the lesson.  If the assignment for a particular user already exists, the user will be reassigned the lesson. By default, an email will be sent to the assignee; it will come from notifications@lesson.ly. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -425,12 +425,14 @@ user_id | yes | Positive Integer | The user to access.  The company must have ac
       {
         "assignable_id": 1,
         "assignable_type": "Lesson",
-        "due_by": "2020-09-30"
+        "due_by": "2020-09-30",
+        "notify": false
       }
       {
         "assignable_id": 3,
         "assignable_type": "Course",
-        "due_by": "2020-09-30"
+        "due_by": "2020-09-30",
+        "notify": false
       }
     ]
 }
@@ -475,7 +477,7 @@ user_id | yes | Positive Integer | The user to access.  The company must have ac
 }
 ```
 
-This endpoint allows you to create assignments for a user. Please note that it will always notify the user. If you want to suppress notifications, use the Lesson Assignments call.
+This endpoint allows you to create assignments for a user.
 
 ### HTTP Request
 
@@ -486,4 +488,4 @@ This endpoint allows you to create assignments for a user. Please note that it w
 Paramter | Required | Type |  Description
 --- | --- | --- | ---
 user_id | yes | Positive Integer | The user to access.  The company must have access to the user.
-assignments | yes | Array |  Array of assignments to be made to the user.  Each requires an assignable_id and assignable_type of "Lesson" or "Course"
+assignments | yes | Array |  Array of assignments to be made to the user.  Each requires an assignable_id and assignable_type of "Lesson" or "Course". By default, an email will be sent to the assignee; it will come from notifications@lesson.ly. To suppress the email notification set `notify` to `false`.

--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -147,7 +147,7 @@ This endpoint allows you to create a user in the api.
 
 ### HTTP Request
 
-`POST https://api.lesson.ly/api/v1/users/ -p params`
+`POST https://api.lesson.ly/api/v1/users/ -d params`
 
 ### Query Parameters
 
@@ -218,7 +218,7 @@ This endpoint allows you to update a user in the api.
 
 ### HTTP Request
 
-`PUT https://api.lesson.ly/api/v1/users/:user_id -p params`
+`PUT https://api.lesson.ly/api/v1/users/:user_id -d params`
 
 ### Query Parameters
 


### PR DESCRIPTION
The documentation referred to a cURL option of `-p` for sending params over. This option should have been `-d`.

A note was also added that notifications upon assignment will take place unless specifically suppressed via `notify:false`.