### PR TITLE
Add user filter example

### DIFF
--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -39,7 +39,7 @@ This endpoint retrieves all users.
 
 ### HTTP Request
 
-`GET https://api.lesson.ly/api/v1/users`
+`GET https://api.lesson.ly/api/v1/users?filter[email]=email@example.com`
 
 ### Query Parameters
 


### PR DESCRIPTION
The example request for `GET /users` didn't include any example for how to use the filter. Here, I add the `?filter` query string as an example.