### PR TITLE
Fixing small typo

### DIFF
--- a/source/includes/_users.md.erb
+++ b/source/includes/_users.md.erb
@@ -158,7 +158,7 @@ email | yes | String | User Email
 role | yes | String | User role. Options: admin, manager, creator, learner
 ext_uid | no | String | The user's ID in another system, useful for linking data.
 notify | no | String | Whether or not to notify the user.  Passing 'false' will not send an email notification to the user that their account has been created. Defaults to 'true'.
-custom_user_fields |  no | Array | Custom user field values for specified custom user field ids. Hashses must containt a "customer_user_field_id" and a "value".
+custom_user_fields |  no | Array | Custom user field values for specified custom user field ids. Hashses must contain a "customer_user_field_id" and a "value".
 
 ## Update User
 


### PR DESCRIPTION
## Purpose
There's a small typo in the API docs I ran across while working on an integration. I figured I would go ahead and submit a fix, since these docs are open source!