### PR TITLE
Update CNAME to docs.lessonly.com

### DIFF
--- a/source/CNAME
+++ b/source/CNAME
@@ -1,1 +1,1 @@
-docs.lesson.ly
+docs.lessonly.com


### PR DESCRIPTION
🎉 Hooray, we're now the proud owners of `lessonly.com`. We want to host our API docs there instead.